### PR TITLE
Allow for images directory to also be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ where `<override-dir>` is an absolute path of a directory that could contain:
 
   - `config.js`: custom config file copied from [here](https://github.com/TryGhost/Ghost/blob/master/config.example.js) (you must replace `127.0.0.1` with `0.0.0.0`)
   - `content/data`: persistent/shared data
+  - `content/images`: persistent/shared images
   - `content/themes`: more themes
 
 After few seconds, open `http://<host>` for blog or `http://<host>/ghost` for admin page.

--- a/start.bash
+++ b/start.bash
@@ -9,6 +9,7 @@ OVERRIDE="/ghost-override"
 
 CONFIG="config.js"
 DATA="content/data"
+IMAGES="content/images"
 THEMES="content/themes"
 
 cd "$GHOST"
@@ -17,6 +18,11 @@ cd "$GHOST"
 mkdir -p "$OVERRIDE/$DATA"
 rm -fr "$DATA"
 ln -s "$OVERRIDE/$DATA" "content"
+
+# Symlink images directory
+mkdir -p "$OVERRIDE/$IMAGES"
+rm -fr "$IMAGES"
+ln -s "$OVERRIDE/$IMAGES" "$IMAGES"
 
 # Symlink config file.
 if [[ -f "$OVERRIDE/$CONFIG" ]]; then


### PR DESCRIPTION
Images are also persisted data, so allow the directory to be overridden in the same manner as the data directory.
