### PR TITLE
Implement Google Analytics (Fixes dockerfile/ghost#14)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ VOLUME ["/data", "/ghost-override"]
 # Define working directory.
 WORKDIR /ghost
 
+# ~~~~ Patches ~~~~~
+# Add Google Analytics script
+RUN mkdir /ghost/patches/
+ADD patches/google_analytics.patch /ghost/patches/google_analytics.patch
+RUN patch -p0 -u < patches/google_analytics.patch
+
 # Define default command.
 CMD ["bash", "/ghost-start"]
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ where `<override-dir>` is an absolute path of a directory that could contain:
   - `content/themes/`: more themes
 
 After few seconds, open `http://<host>` for blog or `http://<host>/ghost` for admin page.
+
+### Patches
+
+This repository also apply the following patches:
+
+ * Google Analytics
+
+#### Google Analytics
+
+In order to make it working you have to set the `GA_ID` environment variable when you start the container.

--- a/patches/google_analytics.patch
+++ b/patches/google_analytics.patch
@@ -1,0 +1,15 @@
+--- content/themes/casper/default.orig.hbs	2014-09-20 10:41:25.000000000 +0200
++++ content/themes/casper/default.hbs	2014-09-20 10:36:17.000000000 +0200
+@@ -33,4 +33,13 @@
+     {{ghost_head}}
++
++    <script>
++        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
++        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
++        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
++        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
++        ga('create', 'UA-XXXXXXX-XX', 'auto');
++        ga('send', 'pageview');
++    </script>
+ </head>
+ <body class="{{body_class}}">

--- a/patches/google_analytics.patch
+++ b/patches/google_analytics.patch
@@ -1,6 +1,7 @@
 --- content/themes/casper/default.orig.hbs	2014-09-20 10:41:25.000000000 +0200
 +++ content/themes/casper/default.hbs	2014-09-20 10:36:17.000000000 +0200
-@@ -33,4 +33,13 @@
+@@ -20,4 +20,13 @@
+
      {{ghost_head}}
 +
 +    <script>

--- a/start.bash
+++ b/start.bash
@@ -35,6 +35,9 @@ if [[ -d "$OVERRIDE/$THEMES" ]]; then
   done
 fi
 
+# Insert the Google Analytics ID
+sed -i 's/UA-XXXXXXX-XX/'$GA_ID'/' /ghost/content/themes/casper/default.hbs
+
 # Start Ghost
 chown -R ghost:ghost /data /ghost /ghost-override
 su ghost << EOF


### PR DESCRIPTION
This pull request add the Google Analytics.

A user can then pass the `GA_ID` within the `docker run` which will then insert it on start.
