### PR TITLE
make uid, gid overridable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN \
   rm -f ghost-latest.zip && \
   cd /ghost && \
   npm install --production && \
-  sed 's/127.0.0.1/0.0.0.0/' /ghost/config.example.js > /ghost/config.js && \
-  useradd ghost --home /ghost
+  sed 's/127.0.0.1/0.0.0.0/' /ghost/config.example.js > /ghost/config.js
 
 # Add files.
 ADD start.bash /ghost-start

--- a/start.bash
+++ b/start.bash
@@ -36,6 +36,8 @@ if [[ -d "$OVERRIDE/$THEMES" ]]; then
 fi
 
 # Start Ghost
+groupadd ghost --gid ${gid:-1000}
+useradd ghost --home /ghost --uid ${uid:-1000} --gid ${gid:-1000}
 chown -R ghost:ghost /data /ghost /ghost-override
 su ghost << EOF
 cd "$GHOST"


### PR DESCRIPTION
#21

Now we can set uid and gid of user `ghost` by passing env vars `uid`, `gid`

e.g. `sudo docker run -d -e gid=1001 -e uid=1001 -p 2368:2368 -v !@#/ghost-override yhpark/ghost`
