### PR TITLE
Running Ghost in development environment with forever in order to watch for changes and restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Pull base image.
 FROM dockerfile/nodejs
 
-# Install Ghost
+# Install Ghost & forever
 RUN \
   cd /tmp && \
   wget https://ghost.org/zip/ghost-latest.zip && \
@@ -18,7 +18,8 @@ RUN \
   sed 's/127.0.0.1/0.0.0.0/' /ghost/config.example.js > /ghost/config.js && \
   mkdir /ghost-override && \
   useradd ghost --home /ghost && \
-  chown -R ghost:ghost /ghost /ghost-override /data
+  chown -R ghost:ghost /ghost /ghost-override /data && \
+  /usr/local/bin/npm install forever -g
 
 # Add files.
 ADD start.bash /ghost-start

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,9 @@ RUN \
   rm -f ghost-latest.zip && \
   cd /ghost && \
   npm install --production && \
+  npm install forever && \
   sed 's/127.0.0.1/0.0.0.0/' /ghost/config.example.js > /ghost/config.js && \
-  mkdir /ghost-override && \
-  useradd ghost --home /ghost && \
-  chown -R ghost:ghost /ghost /ghost-override /data && \
-  /usr/local/bin/npm install forever -g
+  useradd ghost --home /ghost
 
 # Add files.
 ADD start.bash /ghost-start
@@ -35,9 +33,6 @@ WORKDIR /ghost
 
 # Define default command.
 CMD ["bash", "/ghost-start"]
-
-# Run as ghost
-USER ghost
 
 # Expose ports.
 EXPOSE 2368

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
   rm -f ghost-latest.zip && \
   cd /ghost && \
   npm install --production && \
-  npm install forever && \
+  npm install forever -g && \
   sed 's/127.0.0.1/0.0.0.0/' /ghost/config.example.js > /ghost/config.js && \
   useradd ghost --home /ghost
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN \
   cd /ghost && \
   npm install --production && \
   sed 's/127.0.0.1/0.0.0.0/' /ghost/config.example.js > /ghost/config.js && \
-  useradd ghost --home /ghost
+  mkdir /ghost-override && \
+  useradd ghost --home /ghost && \
+  chown -R ghost:ghost /ghost /ghost-override /data
 
 # Add files.
 ADD start.bash /ghost-start
@@ -32,6 +34,9 @@ WORKDIR /ghost
 
 # Define default command.
 CMD ["bash", "/ghost-start"]
+
+# Run as ghost
+USER ghost
 
 # Expose ports.
 EXPOSE 2368

--- a/README.md
+++ b/README.md
@@ -38,13 +38,20 @@ After few seconds, open `http://<host>` for blog or `http://<host>/ghost` for ad
 
 #### Running Ghost in development environment with forever
 
-When running Ghost in node development environment
-
     docker run -d -p 80:2368 -e NODE_ENV=development -e WATCH_DIRECTORY=<dir-to-watch> -v <override-dir>:/ghost-override dockerfile/ghost
 
-Ghost starts with the help of forever https://www.npmjs.com/package/forever and its watchDirectory option.
-This lets us develop on a shared `ghost-override` volume and forever watch for file changes in `watchDirectory` and restart our Ghost process without stoping docker.
+where `<dir-to-watch>` is a relative path to /ghost
+
+##### Why forever
+When Ghost starts with the help of forever https://www.npmjs.com/package/forever and its watchDirectory option.
+Then we can develop on a shared `ghost-override` volume and forever will watch for file changes in `watchDirectory`.
+When we change a file inside `watchDirectory` forever, after a few seconds, restarts the Ghost process without stoping docker.
 
 e.g.
     
-    docker run --rm -e NODE_ENV=development -e WATCH_DIRECTORY=content/themes/my_theme -v /home/my_localhost_ghost:/ghost-override -p 2368:2368 dockerfile/ghost
+    docker run -d -p 80:2368 -e NODE_ENV=development -e WATCH_DIRECTORY=content/themes/my_theme -v /home/my_localhost_ghost:/ghost-override dockerfile/ghost
+
+or in this case better interactive to see when our process restarts
+
+    docker run -p 80:2368 -e NODE_ENV=development -e WATCH_DIRECTORY=content/themes/my_theme -v /home/my_localhost_ghost:/ghost-override dockerfile/ghost
+

--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ where `<override-dir>` is an absolute path of a directory that could contain:
   - `content/themes/`: more themes
 
 After few seconds, open `http://<host>` for blog or `http://<host>/ghost` for admin page.
+
+
+#### Running Ghost in development environment with forever
+
+When running Ghost in node development environment
+
+    docker run -d -p 80:2368 -e NODE_ENV=development -e WATCH_DIRECTORY=<dir-to-watch> -v <override-dir>:/ghost-override dockerfile/ghost
+
+Ghost starts with the help of forever https://www.npmjs.com/package/forever and its watchDirectory option.
+This lets us develop on a shared `ghost-override` volume and forever watch for file changes in `watchDirectory` and restart our Ghost process without stoping docker.
+
+e.g.
+    
+    docker run --rm -e NODE_ENV=development -e WATCH_DIRECTORY=content/themes/my_theme -v /home/my_localhost_ghost:/ghost-override -p 2368:2368 dockerfile/ghost

--- a/start.bash
+++ b/start.bash
@@ -8,6 +8,9 @@ DATA="content/data"
 IMAGES="content/images"
 THEMES="content/themes"
 
+NODE_ENV=${NODE_ENV:-production}
+WATCH_DIRECTORY=${WATCH_DIRECTORY:-$THEMES}
+
 # Symlink data directory.
 mkdir -p "$OVERRIDE/$DATA"
 rm -fr "$DATA"
@@ -34,4 +37,10 @@ if [[ -d "$OVERRIDE/$THEMES" ]]; then
 fi
 
 # Start Ghost
-NODE_ENV=${NODE_ENV:-production} npm start
+if [[ "$NODE_ENV" == "development" ]]; then
+  COMMAND="NODE_ENV=$NODE_ENV forever --watchDirectory=$WATCH_DIRECTORY -w index.js"
+else
+  COMMAND="NODE_ENV=$NODE_ENV npm start"
+fi
+
+echo "$COMMAND" ; eval $COMMAND

--- a/start.bash
+++ b/start.bash
@@ -37,6 +37,9 @@ if [[ -d "$OVERRIDE/$THEMES" ]]; then
 fi
 
 # Start Ghost
+chown -R ghost:ghost /data /ghost /ghost-override
+su ghost
+
 if [[ "$NODE_ENV" == "development" ]]; then
   COMMAND="NODE_ENV=$NODE_ENV forever --watchDirectory=$WATCH_DIRECTORY -w index.js"
 else

--- a/start.bash
+++ b/start.bash
@@ -8,8 +8,6 @@ DATA="content/data"
 IMAGES="content/images"
 THEMES="content/themes"
 
-cd "$GHOST"
-
 # Symlink data directory.
 mkdir -p "$OVERRIDE/$DATA"
 rm -fr "$DATA"
@@ -36,8 +34,4 @@ if [[ -d "$OVERRIDE/$THEMES" ]]; then
 fi
 
 # Start Ghost
-chown -R ghost:ghost /data /ghost /ghost-override
-su ghost << EOF
-cd "$GHOST"
 NODE_ENV=${NODE_ENV:-production} npm start
-EOF


### PR DESCRIPTION
Better `ghost-start` script.
Now when NODE_ENV=development, ghost start using forever and its watch option in order to auto restart after code changes.
When NODE_ENV=production, ghost starts with npm start
