### PR TITLE
Fix nodejs image source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image.
-FROM dockerfile/nodejs
+FROM node:0.12
 
 # Install Ghost
 RUN \


### PR DESCRIPTION
`dockerfile/nodejs` image location does not exist any more and currently unsure if ghost is ready for node 4.0
- [x] Set node js source to `node:0.12`
